### PR TITLE
Removed the dot-syntax from __dirname

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ module.exports = {
 
     // or array of paths
     ['nuxt-sass-resources-loader', [
-        resolve(__.dirname, 'path/to/first-resources.sass'),
-        resolve(__.dirname, 'path/to/second-resources.scss'),
+        resolve(__dirname, 'path/to/first-resources.sass'),
+        resolve(__dirname, 'path/to/second-resources.scss'),
     ]],
 
     // or the native options
     ['nuxt-sass-resources-loader', {
-        resources: resolve(__.dirname, 'path/to/resources.sass')
+        resources: resolve(__dirname, 'path/to/resources.sass')
     }],
   ],
 }
@@ -50,7 +50,7 @@ module.exports = {
     'nuxt-sass-resources-loader'
   ],
   sassResources: [
-    resolve(__.dirname, 'path/to/first-resources.sass')
+    resolve(__dirname, 'path/to/first-resources.sass')
   ]
 }
 ```


### PR DESCRIPTION
Unless I'm mistaken the `.` in the `__.dirname` is [not correct](https://nodejs.org/docs/latest/api/globals.html#globals_dirname) in README.md

Fantastic package by the way, solves a reoccurring pain point we've had with nuxt.