### PR TITLE
Allow modules with no `test` property

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ module.exports = function nuxtSassResourcesLoader (moduleOptions = {}) {
         moduleOptions = {resources: moduleOptions}
     }
 
-    const options = Object.assign({}, defaults, {resources: this.options.sassResources}, moduleOptions) 
-    
+    const options = Object.assign({}, defaults, {resources: this.options.sassResources}, moduleOptions)
+
     // Casts the provided resource as an array if it's not one.
     options.resources = Array.isArray(options.resources) ? options.resources : [options.resources]
 
@@ -38,11 +38,11 @@ module.exports = function nuxtSassResourcesLoader (moduleOptions = {}) {
 }
 
 function extendV1(config, { sassResourcesLoader }) {
-    const sassLoader = config.module.rules.filter(({ test }) => {
-        return !!test ? ['/\\.sass$/', '/\\.scss$/'].indexOf(test.toString()) !== -1 : false;
+    const sassLoader = config.module.rules.filter(({ test = '' }) => {
+        return ['/\\.sass$/', '/\\.scss$/'].indexOf(test.toString()) !== -1
     })
-    const vueLoader = config.module.rules.find(({ test }) => {
-        return !!test ? test.toString() === '/\\.vue$/' : false
+  const vueLoader = config.module.rules.find(({ test = '' }) => {
+        return test.toString() === '/\\.vue$/'
     })
 
     const loaders = vueLoader.options.loaders
@@ -59,8 +59,8 @@ function extendV1(config, { sassResourcesLoader }) {
 }
 
 function extend(config, { sassResourcesLoader }) {
-    const sassLoaders = config.module.rules.filter(({ test }) => {
-        return !!test ? ['/\\.sass$/', '/\\.scss$/'].indexOf(test.toString()) !== -1 : false;
+    const sassLoaders = config.module.rules.filter(({ test = '' }) => {
+        return ['/\\.sass$/', '/\\.scss$/'].indexOf(test.toString()) !== -1
     })
 
     for (const sassLoader of sassLoaders) {
@@ -85,5 +85,5 @@ function resolvePath(_path) {
 
     return this.resolveAlias(_path)
   }
-  
+
 module.exports.meta = require('./package.json')

--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ module.exports = function nuxtSassResourcesLoader (moduleOptions = {}) {
 
 function extendV1(config, { sassResourcesLoader }) {
     const sassLoader = config.module.rules.filter(({ test }) => {
-        return ['/\\.sass$/', '/\\.scss$/'].indexOf(test.toString()) !== -1
+        return !!test ? ['/\\.sass$/', '/\\.scss$/'].indexOf(test.toString()) !== -1 : false;
     })
     const vueLoader = config.module.rules.find(({ test }) => {
-        return test.toString() === '/\\.vue$/'
+        return !!test ? test.toString() === '/\\.vue$/' : false
     })
 
     const loaders = vueLoader.options.loaders
@@ -60,7 +60,7 @@ function extendV1(config, { sassResourcesLoader }) {
 
 function extend(config, { sassResourcesLoader }) {
     const sassLoaders = config.module.rules.filter(({ test }) => {
-        return ['/\\.sass$/', '/\\.scss$/'].indexOf(test.toString()) !== -1
+        return !!test ? ['/\\.sass$/', '/\\.scss$/'].indexOf(test.toString()) !== -1 : false;
     })
 
     for (const sassLoader of sassLoaders) {


### PR DESCRIPTION
Hi, while implementing i18n into my application with vue loader 15, I was receiving build errors that would cause my app to fail.

Reasons for this were due to my use of `resourceQuery` modules, which don't require a `test` property. 

~~This fix will skip over test that don't include it, thus allowing build to complete.~~
This will add default value to `test` (empty string), thus allowing .toString() to be called. Thought this  might match code style a little more.

Sorry for the quick description, if you need extra details please let me know.

Cheers