### PR TITLE
Add file exists check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const Module = require('module')
+const { existsSync } = require('fs')
 
 const defaults = {
     resources: []
@@ -81,9 +82,15 @@ function resolvePath(_path) {
       if (error.code !== 'MODULE_NOT_FOUND') {
         throw error
       }
-    }
+	}
 
-    return this.resolveAlias(_path)
+	const path = this.resolveAlias(_path);
+
+	if (!existsSync(path)) {
+		throw new Error(`Resource '${_path}' does not exist! Is the filename correct?`);
+	}
+
+    return path;
   }
 
 module.exports.meta = require('./package.json')


### PR DESCRIPTION
Glob.sync (used by sass-resource-loader) does not fail if it is unable to find a match using, instead returning an empty array. This can cause confusion if there is a typo, etc in configuration.

This is just an idea for a solution however feel free to update however you like.