### PR TITLE
Revert "Add file exists check"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const Module = require('module')
-const { existsSync } = require('fs')
 
 const defaults = {
     resources: []
@@ -82,15 +81,9 @@ function resolvePath(_path) {
       if (error.code !== 'MODULE_NOT_FOUND') {
         throw error
       }
-	}
+    }
 
-	const path = this.resolveAlias(_path);
-
-	if (!existsSync(path)) {
-		throw new Error(`Resource '${_path}' does not exist! Is the filename correct?`);
-	}
-
-    return path;
+    return this.resolveAlias(_path)
   }
 
 module.exports.meta = require('./package.json')


### PR DESCRIPTION
Reverts anteriovieira/nuxt-sass-resources-loader#19

The tests failed due to the [glob pattern matching](https://github.com/anteriovieira/nuxt-sass-resources-loader#glob-pattern-matching).